### PR TITLE
Fix for parse_ini_file()

### DIFF
--- a/settings.ini.php
+++ b/settings.ini.php
@@ -1,6 +1,6 @@
 ;<?php return; ?>
 [SQL]
-host = localhost
-user = root
-password = 
-dbname = testdb
+host = 'localhost'
+user = 'root'
+password = ''
+dbname = 'testdb'


### PR DESCRIPTION
In DB.class.php parse_ini_file() is used to read settings but the
function returns false as it searchs for strings.